### PR TITLE
Updated api documentation to reflect implementation.

### DIFF
--- a/cakeshop-api/src/main/webapp/api/swagger.json
+++ b/cakeshop-api/src/main/webapp/api/swagger.json
@@ -416,7 +416,7 @@
 				],
 				"parameters": [
 					{
-						"name": "id",
+						"name": "address",
 						"type": "string",
 						"description": "ID (address) of Contract to retrieve",
 						"example": "0x01f999deef030a0f3c55cec46e6693c06c6b01f8",

--- a/cakeshop-api/src/main/webapp/api/swagger.json
+++ b/cakeshop-api/src/main/webapp/api/swagger.json
@@ -282,6 +282,12 @@
 				],
 				"parameters": [
 					{
+						"name": "from",
+						"type": "string",
+						"description": "Wallet that is sending the Contract, wallet has to be unlocked and has to have a positive balance.",
+						"in": "body"
+					},
+          {
 						"name": "code",
 						"type": "string",
 						"description": "Contract source code",


### PR DESCRIPTION
/contact/get accepts parameter 'address' not 'id'.
/contact/create parameter 'from' is now documented.