### PR TITLE
Upgrade Spring5 boot2 jackson hibernate jetty junit5

### DIFF
--- a/cakeshop-api/pom.xml
+++ b/cakeshop-api/pom.xml
@@ -268,18 +268,18 @@
         </dependency>
         <dependency>
             <groupId>org.thymeleaf</groupId>
-            <artifactId>thymeleaf-spring4</artifactId>
-            <version>2.1.4.RELEASE</version>
+            <artifactId>thymeleaf-spring5</artifactId>
+            <version>3.0.9.RELEASE</version>
         </dependency>
-        <dependency>
-            <groupId>org.thymeleaf.extras</groupId>
-            <artifactId>thymeleaf-extras-springsecurity4</artifactId>
-            <version>2.1.3.RELEASE</version>
-        </dependency>
+      <dependency>
+        <groupId>org.thymeleaf.extras</groupId>
+        <artifactId>thymeleaf-extras-springsecurity4</artifactId>
+        <version>3.0.2.RELEASE</version>
+      </dependency>
         <dependency>
             <groupId>nz.net.ultraq.thymeleaf</groupId>
             <artifactId>thymeleaf-layout-dialect</artifactId>
-            <version>2.2.0</version>
+            <version>2.3.0</version>
         </dependency>
         <dependency>
             <groupId>io.springfox</groupId>
@@ -369,7 +369,7 @@
                 <!-- Import dependency management from Spring Boot -->
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>1.4.3.RELEASE</version>
+                <version>${spring.boot.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/config/AppStartup.java
+++ b/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/config/AppStartup.java
@@ -5,13 +5,17 @@ import com.jpmorgan.cakeshop.bean.GethConfigBean;
 import com.jpmorgan.cakeshop.error.APIException;
 import com.jpmorgan.cakeshop.error.ErrorLog;
 import com.jpmorgan.cakeshop.service.GethHttpService;
-import com.jpmorgan.cakeshop.util.EEUtils;
-import com.jpmorgan.cakeshop.util.FileUtils;
-import com.jpmorgan.cakeshop.util.MemoryUtils;
-import com.jpmorgan.cakeshop.util.ProcessUtils;
-import com.jpmorgan.cakeshop.util.StreamGobbler;
-import com.jpmorgan.cakeshop.util.StringUtils;
+import com.jpmorgan.cakeshop.util.*;
+import org.apache.commons.lang3.SystemUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Service;
 
+import javax.servlet.ServletContext;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
@@ -20,18 +24,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import javax.servlet.ServletContext;
-
-import org.apache.commons.lang3.SystemUtils;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.context.embedded.EmbeddedServletContainerInitializedEvent;
-import org.springframework.context.ApplicationEvent;
-import org.springframework.context.ApplicationListener;
-import org.springframework.context.event.ContextRefreshedEvent;
-import org.springframework.core.annotation.Order;
-import org.springframework.stereotype.Service;
 
 @Order(999999)
 @Service(value = "appStartup")
@@ -66,13 +58,14 @@ public class AppStartup implements ApplicationListener<ApplicationEvent> {
     @Override
     public void onApplicationEvent(ApplicationEvent event) {
 
-        if (event instanceof EmbeddedServletContainerInitializedEvent) {
+      /* event deprecated in spring boot 2.x releases
+      if (event instanceof EmbeddedServletContainerInitializedEvent) {
             // this event fires after context refresh and after geth has started
             int port = ((EmbeddedServletContainerInitializedEvent) event).getEmbeddedServletContainer().getPort();
             System.out.println("          url:         " + getSpringUrl(port));
             System.out.println();
             return;
-        }
+        }*/
 
         if (!(event instanceof ContextRefreshedEvent)) {
             return;

--- a/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/config/SpringBootApplication.java
+++ b/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/config/SpringBootApplication.java
@@ -3,6 +3,17 @@ package com.jpmorgan.cakeshop.config;
 import com.jpmorgan.cakeshop.bean.GethConfigBean;
 import com.jpmorgan.cakeshop.util.FileUtils;
 import com.jpmorgan.cakeshop.util.StringUtils;
+import org.apache.commons.lang3.SystemUtils;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.web.embedded.jetty.JettyServletWebServerFactory;
+import org.springframework.boot.web.server.ErrorPage;
+import org.springframework.boot.web.servlet.server.ConfigurableServletWebServerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
 
 import java.io.File;
 import java.io.IOException;
@@ -10,16 +21,6 @@ import java.net.URL;
 import java.util.Enumeration;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
-
-import org.apache.commons.lang3.SystemUtils;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.boot.context.embedded.EmbeddedServletContainerFactory;
-import org.springframework.boot.context.embedded.jetty.JettyEmbeddedServletContainerFactory;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 
 @Configuration
 @EnableAutoConfiguration
@@ -111,10 +112,11 @@ public class SpringBootApplication {
 
     @Bean
     @Profile("spring-boot")
-    public EmbeddedServletContainerFactory embeddedServletContainerFactory() {
-        JettyEmbeddedServletContainerFactory jetty = new JettyEmbeddedServletContainerFactory();
-        jetty.setContextPath("/cakeshop");
-        return jetty;
+    public ConfigurableServletWebServerFactory webServerFactory() {
+      JettyServletWebServerFactory factory = new JettyServletWebServerFactory();
+      factory.setContextPath("/cakeshop");
+      factory.addErrorPages(new ErrorPage(HttpStatus.NOT_FOUND, "/notfound.html"));
+      return factory;
     }
 
 }

--- a/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/config/WebAppInit.java
+++ b/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/config/WebAppInit.java
@@ -2,18 +2,16 @@ package com.jpmorgan.cakeshop.config;
 
 import com.jcabi.manifests.Manifests;
 import com.jcabi.manifests.ServletMfs;
-
-import java.io.IOException;
-
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.context.web.SpringBootServletInitializer;
+import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import java.io.IOException;
 
 @Configuration
 @EnableAutoConfiguration

--- a/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/config/WebConfig.java
+++ b/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/config/WebConfig.java
@@ -1,31 +1,26 @@
 package com.jpmorgan.cakeshop.config;
 
-import java.io.FileInputStream;
-import java.util.Properties;
-
-import javax.annotation.PreDestroy;
-
+import com.jpmorgan.cakeshop.util.FileUtils;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.OkHttpClient;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
-import org.springframework.web.servlet.config.annotation.AsyncSupportConfigurer;
-import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.DefaultServletHandlerConfigurer;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
-
-import okhttp3.OkHttpClient;
 import org.springframework.web.servlet.ViewResolver;
-import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
-import org.thymeleaf.spring4.SpringTemplateEngine;
-import org.thymeleaf.spring4.view.ThymeleafViewResolver;
+import org.springframework.web.servlet.config.annotation.*;
+import org.thymeleaf.spring5.SpringTemplateEngine;
+import org.thymeleaf.spring5.view.ThymeleafViewResolver;
 import org.thymeleaf.templateresolver.ServletContextTemplateResolver;
 
-import org.springframework.beans.factory.annotation.Value;
-import com.jpmorgan.cakeshop.util.FileUtils;
+import javax.annotation.PreDestroy;
+import javax.servlet.ServletContext;
+import java.io.FileInputStream;
+import java.util.Properties;
 
 /**
  *
@@ -33,6 +28,7 @@ import com.jpmorgan.cakeshop.util.FileUtils;
  */
 @Configuration
 @EnableScheduling
+@Slf4j
 public class WebConfig extends WebMvcConfigurerAdapter {
 
 	private static final org.slf4j.Logger LOG = org.slf4j.LoggerFactory.getLogger(WebConfig.class);
@@ -45,6 +41,9 @@ public class WebConfig extends WebMvcConfigurerAdapter {
 
     @Autowired
     private OkHttpClient okHttpClient;
+
+    @Autowired
+    private ServletContext servletContext;
 
     @Override
     public void configureAsyncSupport(AsyncSupportConfigurer configurer) {
@@ -85,7 +84,7 @@ public class WebConfig extends WebMvcConfigurerAdapter {
 
     @Bean
     public ServletContextTemplateResolver templateResolver() {
-        ServletContextTemplateResolver templateResolver = new ServletContextTemplateResolver();
+        ServletContextTemplateResolver templateResolver = new ServletContextTemplateResolver(servletContext);
         templateResolver.setCacheable(false);
         templateResolver.setTemplateMode("HTML5");
         templateResolver.setCharacterEncoding("UTF-8");
@@ -126,6 +125,7 @@ public class WebConfig extends WebMvcConfigurerAdapter {
     public AsyncTaskExecutor createMvcAsyncExecutor() {
         ThreadPoolTaskExecutor exec = new ThreadPoolTaskExecutor();
         exec.setBeanName("asyncTaskExecutor");
+        log.info("async task pool thread core {}",env.getProperty("cakeshop.mvc.async.pool.threads.core"));
         exec.setCorePoolSize(Integer.valueOf(env.getProperty("cakeshop.mvc.async.pool.threads.core")));
         exec.setMaxPoolSize(Integer.valueOf(env.getProperty("cakeshop.mvc.async.pool.threads.max")));
         exec.setQueueCapacity(Integer.valueOf(env.getProperty("cakeshop.mvc.async.pool.queue.max")));

--- a/cakeshop-api/src/main/java/org/springframework/http/client/OkHttp3AsyncClientHttpRequest.java
+++ b/cakeshop-api/src/main/java/org/springframework/http/client/OkHttp3AsyncClientHttpRequest.java
@@ -16,19 +16,14 @@
 
 package org.springframework.http.client;
 
-import java.io.IOException;
-import java.net.URI;
-
-import okhttp3.Call;
-import okhttp3.Callback;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.Response;
-
+import okhttp3.*;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.util.concurrent.ListenableFuture;
 import org.springframework.util.concurrent.SettableListenableFuture;
+
+import java.io.IOException;
+import java.net.URI;
 
 /**
  * {@link AsyncClientHttpRequest} implementation that uses OkHttp 3.x to execute requests.
@@ -61,7 +56,12 @@ class OkHttp3AsyncClientHttpRequest extends AbstractBufferingAsyncClientHttpRequ
 		return this.method;
 	}
 
-	@Override
+  @Override
+  public String getMethodValue() {
+    return method.name();
+  }
+
+  @Override
 	public URI getURI() {
 		return this.uri;
 	}

--- a/cakeshop-api/src/main/java/org/springframework/http/client/OkHttp3ClientHttpRequest.java
+++ b/cakeshop-api/src/main/java/org/springframework/http/client/OkHttp3ClientHttpRequest.java
@@ -16,14 +16,13 @@
 
 package org.springframework.http.client;
 
-import java.io.IOException;
-import java.net.URI;
-
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
-
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+
+import java.io.IOException;
+import java.net.URI;
 
 /**
  * {@link ClientHttpRequest} implementation that uses OkHttp 3.x to execute requests.
@@ -56,7 +55,12 @@ class OkHttp3ClientHttpRequest extends AbstractBufferingClientHttpRequest {
 		return this.method;
 	}
 
-	@Override
+  @Override
+  public String getMethodValue() {
+    return this.method.name();
+  }
+
+  @Override
 	public URI getURI() {
 		return this.uri;
 	}

--- a/cakeshop-api/src/main/resources/404.html
+++ b/cakeshop-api/src/main/resources/404.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Page Not Found</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+        * {
+            line-height: 1.2;
+            margin: 0;
+        }
+        html {
+            color: #888;
+            display: table;
+            font-family: sans-serif;
+            height: 100%;
+            text-align: center;
+            width: 100%;
+        }
+        body {
+            display: table-cell;
+            vertical-align: middle;
+            margin: 2em auto;
+        }
+        h1 {
+            color: #555;
+            font-size: 2em;
+            font-weight: 400;
+        }
+        p {
+            margin: 0 auto;
+            width: 280px;
+        }
+        @media only screen and (max-width: 280px) {
+            body, p {
+                width: 95%;
+            }
+            h1 {
+                font-size: 1.5em;
+                margin: 0 0 0.3em;
+            }
+        }
+    </style>
+</head>
+<body>
+<h1>Page Not Found</h1>
+<p>Sorry, but the page you were trying to view does not exist.</p>
+</body>
+</html>

--- a/cakeshop-client-java-codegen/pom.xml
+++ b/cakeshop-client-java-codegen/pom.xml
@@ -83,6 +83,7 @@
     <dependency>
       <groupId>org.apache.velocity</groupId>
       <artifactId>velocity</artifactId>
+      <version>1.7</version>
     </dependency>
 
 

--- a/cakeshop-client-java/src/main/java/com/jpmorgan/cakeshop/client/ws/JsonMessageConverter.java
+++ b/cakeshop-client-java/src/main/java/com/jpmorgan/cakeshop/client/ws/JsonMessageConverter.java
@@ -1,14 +1,13 @@
 package com.jpmorgan.cakeshop.client.ws;
 
 import com.google.common.collect.Lists;
-
-import java.nio.charset.Charset;
-
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.converter.AbstractMessageConverter;
 import org.springframework.util.MimeType;
 import org.springframework.util.MimeTypeUtils;
+
+import java.nio.charset.Charset;
 
 public class JsonMessageConverter extends AbstractMessageConverter {
 
@@ -46,8 +45,8 @@ public class JsonMessageConverter extends AbstractMessageConverter {
     }
 
     private Charset getContentTypeCharset(MimeType mimeType) {
-        if (mimeType != null && mimeType.getCharSet() != null) {
-            return mimeType.getCharSet();
+        if (mimeType != null && mimeType.getCharset() != null) {
+            return mimeType.getCharset();
         }
         else {
             return this.defaultCharset;

--- a/cakeshop-node-manager/src/main/java/com/jpmorgan/cakeshop/manager/CakeshopNodeManager.java
+++ b/cakeshop-node-manager/src/main/java/com/jpmorgan/cakeshop/manager/CakeshopNodeManager.java
@@ -1,16 +1,18 @@
 package com.jpmorgan.cakeshop.manager;
 
-import java.util.concurrent.TimeUnit;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
-import org.springframework.boot.context.embedded.EmbeddedServletContainerFactory;
-import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory;
-import org.springframework.boot.web.support.SpringBootServletInitializer;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.servlet.server.ConfigurableServletWebServerFactory;
+import org.springframework.boot.web.servlet.server.Session;
+import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+
+import java.time.Duration;
 
 @Configuration
 @ComponentScan
@@ -30,10 +32,11 @@ public class CakeshopNodeManager extends SpringBootServletInitializer {
 
     @Bean
     @Profile("spring-boot")
-    public EmbeddedServletContainerFactory servletContainer() {
-        TomcatEmbeddedServletContainerFactory factory
-                = new TomcatEmbeddedServletContainerFactory();
-        factory.setSessionTimeout(15, TimeUnit.MINUTES);
+      public ConfigurableServletWebServerFactory servletContainer(Session session) {
+        TomcatServletWebServerFactory factory = new TomcatServletWebServerFactory();
+        session.setTimeout(Duration.ofMinutes(15));
+        factory.setSession(session);
         return factory;
     }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>1.4.3.RELEASE</version>
+    <version>2.0.3.RELEASE</version>
   </parent>
 
   <groupId>com.jpmorgan</groupId>
@@ -25,25 +25,15 @@
     <endorsed.dir>${project.build.directory}/endorsed</endorsed.dir>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.8</java.version>
-
-    <spring.version>4.3.5.RELEASE</spring.version>
-    <spring.boot.version>1.4.3.RELEASE</spring.boot.version>
-
-    <!-- jetty 9.2.x is compat with java 7+ (9.3.x requires 8+) -->
-    <jetty.version>9.2.19.v20160908</jetty.version>
-
-    <gson.version>1.7.1</gson.version>
-    <jackson.version>2.6.3</jackson.version>
-    <slf4j.version>1.7.7</slf4j.version>
-    <guava.version>19.0</guava.version>
+    <spring.boot.version>2.0.3.RELEASE</spring.boot.version>
+    <jetty.version>9.4.9.v20180320</jetty.version>
+    <gson.version>2.8.5</gson.version>
+    <guava.version>23.0</guava.version>
     <dropwizard-metrics.version>3.1.2</dropwizard-metrics.version>
-
-    <hibernate.version>5.1.0.Final</hibernate.version>
     <hsqldb.version>2.3.3</hsqldb.version>
     <mysql.version>5.1.9</mysql.version>
     <postgres.version>9.3-1102-jdbc41</postgres.version>
     <oracle.version>11.2.0.4</oracle.version>
-    <junit.version>4.11</junit.version>
   </properties>
 
   <modules>
@@ -56,6 +46,29 @@
     <module>cakeshop-node-manager</module>
   </modules>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>1.16.22</version>
+    </dependency>
+  </dependencies>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>5.2.0</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-thymeleaf</artifactId>
+        <version>${spring.boot.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <build>
     <plugins>
       <plugin>
@@ -64,7 +77,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-scm-plugin</artifactId>
-        <version>1.9.5</version>
+        <version>1.10.0</version>
         <configuration>
           <tag>cakeshop-${project.version}</tag>
         </configuration>


### PR DESCRIPTION
Most of the third party jars used in cakeshop seems to be quite old. Most of these jars have security vulnerabilities. To start with, Jackson API have been proven to be quite vulnerable to different attacks such as json injection, yml bombs etc. Similarly other API versions used in the projects have shown less resistance to recent attacks. NIST DB has all these details. Recently Pivotal has release upgraded version to address most of these problems (Spring Boot 2.X). Upgrading to this version assures more certainty that app is secured from external attacks. This upgrade required other supporting API to upgrade too. Following are the major upgrades done in this pull request:

Spring Boot : 2.0.3.RELEASE
Spring          : version 5
Hibernate     : 5.2.17.Final
Jetty              : 9.4.9.v20180320
Junit              : version 5
Jackson         : 2.9.6

I am running the app in my local and seems to be working fine. All the test cases are passing too. I will start on actual hackathon challenge now. Hopefully i will contribute something  :). Cheers
