### PR TITLE
Process account funds using hex encoded BigInts

### DIFF
--- a/cakeshop-abi/src/main/java/com/jpmorgan/cakeshop/util/AbiUtils.java
+++ b/cakeshop-abi/src/main/java/com/jpmorgan/cakeshop/util/AbiUtils.java
@@ -94,6 +94,24 @@ public class AbiUtils {
 	    return "0x" + Hex.toHexString(input.toByteArray());
 	}
 
+	public static String toHexWithNoLeadingZeros(BigInteger input) {
+		// Convert BigInteger to String based hex representtion
+		String hex = Hex.toHexString(input.toByteArray());
+		
+		// Remove leading 0s in string from non-zero hex values
+		if (hex.startsWith("0") && hex.length() > 1) {
+			hex = hex.replaceFirst("^0+", "");
+
+			// In case the value was all zeros
+			if (hex.length() == 0) {
+				hex = "0";
+			}
+		}
+
+		// Prefix hex string with 0x
+	    return "0x" + hex;
+	}
+
 	public static String toHex(Long input) {
 	    return "0x" + Long.toHexString(input);
 	}

--- a/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/model/json/WalletPostJsonRequest.java
+++ b/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/model/json/WalletPostJsonRequest.java
@@ -1,9 +1,11 @@
 package com.jpmorgan.cakeshop.model.json;
 
+import java.math.BigInteger;
+
 public class WalletPostJsonRequest {
 
     private String fromAccount, account, accountPassword;
-    private Long newBalance;
+    private BigInteger newBalance;
 
     /**
      * @return the formAccount
@@ -50,14 +52,14 @@ public class WalletPostJsonRequest {
     /**
      * @return the newBalance
      */
-    public Long getNewBalance() {
+    public BigInteger getNewBalance() {
         return newBalance;
     }
 
     /**
      * @param newBalance the newBalance to set
      */
-    public void setNewBalance(Long newBalance) {
+    public void setNewBalance(BigInteger newBalance) {
         this.newBalance = newBalance;
     }
 

--- a/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/service/impl/WalletServiceImpl.java
+++ b/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/service/impl/WalletServiceImpl.java
@@ -120,7 +120,7 @@ public class WalletServiceImpl implements WalletService, GethRpcConstants {
             Map<String, Object> fundArgs = new HashMap<>();
             fundArgs.put("from", accountFrom);
             fundArgs.put("to", request.getAccount());
-            fundArgs.put("value", request.getNewBalance());
+            fundArgs.put("value", AbiUtils.toHexWithNoLeadingZeros(request.getNewBalance()));
             Map<String, Object> result = gethService.executeGethCall("eth_sendTransaction", new Object[]{fundArgs});
             String response = result.get("_result").toString();
             if (StringUtils.isNotBlank(response)) {


### PR DESCRIPTION
Code to fix wallet fund transfers. See issue #84
Hex encoding allows for transfers to be accepted and converting the underlying value datatype from Long to BigInteger allows for any amount (large amounts) of an account balance to be transferred in one transaction.

