### PR TITLE
Increse max value for network_id

### DIFF
--- a/cakeshop-api/pom.xml
+++ b/cakeshop-api/pom.xml
@@ -445,6 +445,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+			    <version>3.0.0-M1</version>
                 <configuration>
                     <skipTests>${skipTests}</skipTests>
                 </configuration>

--- a/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/bean/GethConfigBean.java
+++ b/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/bean/GethConfigBean.java
@@ -396,11 +396,11 @@ public class GethConfigBean {
         props.setProperty(GETH_AUTO_STOP, autoStop.toString());
     }
 
-    public Integer getNetworkId() {
-        return Integer.valueOf(get(GETH_NETWORK_ID, "1006"));
+    public Long getNetworkId() {
+        return Long.valueOf(get(GETH_NETWORK_ID, "1006"));
     }
 
-    public void setNetworkId(Integer networkId) {
+    public void setNetworkId(Long networkId) {
         props.setProperty(GETH_NETWORK_ID, networkId.toString());
     }
 

--- a/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/controller/NodeController.java
+++ b/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/controller/NodeController.java
@@ -108,7 +108,7 @@ public class NodeController extends BaseController {
             }
 
             if (!StringUtils.isEmpty(jsonRequest.getNetworkId())) {
-                nodeSettings.networkId(Integer.parseInt(jsonRequest.getNetworkId()));
+                nodeSettings.networkId(Long.parseLong(jsonRequest.getNetworkId()));
             }
 
             if (jsonRequest.getCommittingTransactions() != null) {

--- a/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/model/NodeConfig.java
+++ b/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/model/NodeConfig.java
@@ -10,12 +10,12 @@ public class NodeConfig {
 
     private String identity;
     private Boolean committingTransactions;
-    private Integer networkId;
+    private Long networkId;
     private Integer logLevel;
     private String genesisBlock;
     private String extraParams;
 
-    public NodeConfig (String identity, Boolean mining, Integer networkid, Integer verbosity, String genesisBlock, String extraParams) {
+    public NodeConfig (String identity, Boolean mining, Long networkid, Integer verbosity, String genesisBlock, String extraParams) {
         this.identity = identity;
         this.committingTransactions = mining;
         this.networkId = networkid;
@@ -55,14 +55,14 @@ public class NodeConfig {
     /**
      * @return the networkId
      */
-    public Integer getNetworkId() {
+    public Long getNetworkId() {
         return networkId;
     }
 
     /**
      * @param networkId the networkId to set
      */
-    public void setNetworkid(Integer networkId) {
+    public void setNetworkid(Long networkId) {
         this.networkId = networkId;
     }
 

--- a/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/model/NodeSettings.java
+++ b/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/model/NodeSettings.java
@@ -8,7 +8,8 @@ package com.jpmorgan.cakeshop.model;
 public class NodeSettings {
 
     private String identity, extraParams, genesisBlock, blockMakerAccount, voterAccount;
-    private Integer minBlockTime, maxBlockTime, logLevel, networkId;
+    private Integer minBlockTime, maxBlockTime, logLevel;
+    private Long networkId;
     private Boolean isMining;
 
     public NodeSettings() {
@@ -37,18 +38,18 @@ public class NodeSettings {
     /**
      * @return the networkId
      */
-    public Integer getNetworkId() {
+    public Long getNetworkId() {
         return networkId;
     }
 
     /**
      * @param networkId the networkId to set
      */
-    public void setNetworkId(Integer networkId) {
+    public void setNetworkId(Long networkId) {
         this.networkId = networkId;
     }
 
-    public NodeSettings networkId(Integer networkId) {
+    public NodeSettings networkId(Long networkId) {
         this.networkId = networkId;
         return this;
     }

--- a/cakeshop-client-java-codegen/pom.xml
+++ b/cakeshop-client-java-codegen/pom.xml
@@ -138,6 +138,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+		<version>3.0.0-M1</version>
         <configuration>
           <skipTests>${skipTests}</skipTests>
         </configuration>

--- a/cakeshop-client-java-sample/pom.xml
+++ b/cakeshop-client-java-sample/pom.xml
@@ -88,6 +88,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+		<version>3.0.0-M1</version>
         <configuration>
           <skipTests>${skipTests}</skipTests>
         </configuration>

--- a/cakeshop-client-java/pom.xml
+++ b/cakeshop-client-java/pom.xml
@@ -204,6 +204,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+		<version>3.0.0-M1</version>
         <configuration>
           <skipTests>${skipTests}</skipTests>
         </configuration>


### PR DESCRIPTION
In some networks (like alastria https://github.com/alastria/alastria-node/wiki/private_transactions_in_alastria) a network_id with integer range its to small

`[ERROR] 2018-12-03 15:57:09.805 [main] SpringApplication - Application startup failed
java.lang.NumberFormatException: For input string: "82584648528"
        at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65) ~[?:1.8.0_191]
        at java.lang.Integer.parseInt(Integer.java:583) ~[?:1.8.0_191]
        at java.lang.Integer.valueOf(Integer.java:766) ~[?:1.8.0_191]
        at com.jpmorgan.cakeshop.bean.GethConfigBean.getNetworkId(GethConfigBean.java:384) ~[classes!/:0.10.0]
        at com.jpmorgan.cakeshop.service.impl.NodeServiceImpl.createNodeConfig(NodeServiceImpl.java:171) ~[classes!/:0.10.0]
        at com.jpmorgan.cakeshop.service.impl.NodeServiceImpl.update(NodeServiceImpl.java:273) ~[classes!/:0.10.0]
        at com.jpmorgan.cakeshop.service.task.BlockchainInitializerTask.deployContractRegistry(BlockchainInitializerTask.java:153) ~[classes!/:0.10.0]
        at com.jpmorgan.cakeshop.service.task.BlockchainInitializerTask.run(BlockchainInitializerTask.java:76) ~[classes!/:0.10.0]
        at com.jpmorgan.cakeshop.service.impl.GethHttpServiceImpl.runPostStartupTasks(GethHttpServiceImpl.java:449) ~[classes!/:0.10.0]
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_191]`

I change type for networkid from Integer to Long.


