### PR TITLE
Fix bug and modify the refresh rete of node log

### DIFF
--- a/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/service/impl/WebSocketPushServiceImpl.java
+++ b/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/service/impl/WebSocketPushServiceImpl.java
@@ -231,8 +231,7 @@ public class WebSocketPushServiceImpl implements WebSocketPushService {
             gethLogSessions++;
             if (gethLogSessions == 1) {
                 LOG.info("Starting  Tailier");
-                tailer = Tailer.create(new File(GETH_LOG_PATH), logListener, 1);
-                tailer.run();
+                tailer = Tailer.create(new File(GETH_LOG_PATH), logListener, 500);
             }
             if (openedSessions > 1) {
                 openedSessions--;


### PR DESCRIPTION
1 Tailer.create method automatically starts the process of monitoring the log,
we don't need call tailer.run, it will start another monitoring instance and print same log twice.
2 It's appropriate to modidy the refresh rete of node log to 500 milliseconds, 1 milliseconds is too fast

Signed-off-by: Zeyu Zhu <zhuzeyu0409@gmail.com>