### PR TITLE
Stores node list in DB, adds ability to prepopulate nodes from json

### DIFF
--- a/7nodes.json
+++ b/7nodes.json
@@ -1,68 +1,37 @@
-{
-  "network": "7nodes",
-  "nodes": [
-    {
-      "name": "node1",
-      "geth": {
-        "url": "http://localhost:22000"
-      },
-      "tessera": {
-        "url": "http://localhost:9001"
-      }
-    },
-    {
-      "name": "node2",
-      "geth": {
-        "url": "http://localhost:22001"
-      },
-      "tessera": {
-        "url": "http://localhost:9002"
-      }
-    },
-    {
-      "name": "node3",
-      "geth": {
-        "url": "http://localhost:22002"
-      },
-      "tessera": {
-        "url": "http://localhost:9003"
-      }
-    },
-    {
-      "name": "node4",
-      "geth": {
-        "url": "http://localhost:22003"
-      },
-      "tessera": {
-        "url": "http://localhost:9004"
-      }
-    },
-    {
-      "name": "node5",
-      "geth": {
-        "url": "http://localhost:22004"
-      },
-      "tessera": {
-        "url": "http://localhost:9005"
-      }
-    },
-    {
-      "name": "node6",
-      "geth": {
-        "url": "http://localhost:22005"
-      },
-      "tessera": {
-        "url": "http://localhost:9006"
-      }
-    },
-    {
-      "name": "node7",
-      "geth": {
-        "url": "http://localhost:22006"
-      },
-      "tessera": {
-        "url": "http://localhost:9007"
-      }
-    }
-  ]
-}
+[
+  {
+    "name": "node1",
+    "rpcUrl": "http://localhost:22000",
+    "transactionManagerUrl": "http://localhost:9001"
+  },
+  {
+    "name": "node2",
+    "rpcUrl": "http://localhost:22001",
+    "transactionManagerUrl": "http://localhost:9002"
+  },
+  {
+    "name": "node3",
+    "rpcUrl": "http://localhost:22002",
+    "transactionManagerUrl": "http://localhost:9003"
+  },
+  {
+    "name": "node4",
+    "rpcUrl": "http://localhost:22003",
+    "transactionManagerUrl": "http://localhost:9004"
+  },
+  {
+    "name": "node5",
+    "rpcUrl": "http://localhost:22004",
+    "transactionManagerUrl": "http://localhost:9005"
+  },
+  {
+    "name": "node6",
+    "rpcUrl": "http://localhost:22005",
+    "transactionManagerUrl": "http://localhost:9006"
+  },
+  {
+    "name": "node7",
+    "rpcUrl": "http://localhost:22006",
+    "transactionManagerUrl": "http://localhost:9007"
+  }
+]

--- a/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/dao/NodeInfoDAO.java
+++ b/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/dao/NodeInfoDAO.java
@@ -1,0 +1,74 @@
+package com.jpmorgan.cakeshop.dao;
+
+import com.jpmorgan.cakeshop.model.NodeInfo;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import org.hibernate.Session;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+public class NodeInfoDAO extends BaseDAO {
+
+    static final Logger LOG = LoggerFactory.getLogger(NodeInfoDAO.class);
+
+
+    @Transactional
+    public NodeInfo getById(String id) throws IOException {
+        if (null != getCurrentSession()) {
+            NodeInfo nodeInfo = getCurrentSession().get(NodeInfo.class, id);
+            return nodeInfo;
+        }
+        return null;
+    }
+
+    @Transactional
+    public void save(NodeInfo nodeInfo) throws IOException {
+        if (null != getCurrentSession()) {
+            getCurrentSession().save(nodeInfo);
+        }
+    }
+
+    @Transactional
+    public void save(List<NodeInfo> nodes) {
+        Session currentSession = getCurrentSession();
+        if (null != currentSession) {
+            for (NodeInfo node : nodes) {
+                LOG.info("Saving nodeInfo {}", node);
+                currentSession.save(node);
+            }
+        }
+    }
+
+    @Transactional
+    public void delete(NodeInfo nodeInfo) throws IOException {
+        if (null != getCurrentSession()) {
+            LOG.info("Deleting nodeInfo");
+            getCurrentSession().delete(nodeInfo);
+        }
+    }
+
+    @Override
+    @Transactional
+    public void reset() {
+        if (null != getCurrentSession()) {
+            Session session = getCurrentSession();
+            session.createSQLQuery("TRUNCATE TABLE NODE_INFO").executeUpdate();
+            session.flush();
+            session.clear();
+        }
+    }
+
+    @Transactional
+    public List<NodeInfo> list() {
+        if (null != getCurrentSession()) {
+            Session session = getCurrentSession();
+            List<NodeInfo> nodes = session.createCriteria(NodeInfo.class).list();
+            return nodes;
+        }
+        return Collections.emptyList();
+    }
+}

--- a/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/model/NodeInfo.java
+++ b/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/model/NodeInfo.java
@@ -1,0 +1,56 @@
+package com.jpmorgan.cakeshop.model;
+
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.jpmorgan.cakeshop.util.StringUtils;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+
+@Entity
+@Table(name = "NODE_INFO")
+public class NodeInfo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE)
+    public Long id;
+
+    public String name;
+
+    public String rpcUrl;
+
+    public String transactionManagerUrl;
+
+    @JsonInclude()
+    @Transient
+    public boolean isSelected = false;
+
+    public NodeInfo() {
+    }
+
+    public NodeInfo(String name, String rpcUrl, String transactionManagerUrl) {
+        this(null, name, rpcUrl, transactionManagerUrl);
+    }
+
+    public NodeInfo(Long id, String name, String rpcUrl, String transactionManagerUrl) {
+        this.id = id;
+        this.name = name;
+        this.rpcUrl = rpcUrl;
+        this.transactionManagerUrl = transactionManagerUrl;
+    }
+
+    @Override
+    public String toString() {
+        return StringUtils.toString(this);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return EqualsBuilder.reflectionEquals(this, obj, false);
+    }
+
+}

--- a/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/service/impl/GethHttpServiceImpl.java
+++ b/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/service/impl/GethHttpServiceImpl.java
@@ -28,6 +28,7 @@ import com.jpmorgan.cakeshop.model.Account;
 import com.jpmorgan.cakeshop.model.RequestModel;
 import com.jpmorgan.cakeshop.service.GethHttpService;
 import com.jpmorgan.cakeshop.service.WalletService;
+import com.jpmorgan.cakeshop.service.task.InitializeNodesTask;
 import com.jpmorgan.cakeshop.service.task.LoadPeersTask;
 import com.jpmorgan.cakeshop.util.FileUtils;
 import com.jpmorgan.cakeshop.util.ProcessUtils;
@@ -430,6 +431,9 @@ public class GethHttpServiceImpl implements GethHttpService {
 
     @Override
     public void runPostStartupTasks() {
+        // Make sure initial nodes are in the DB if file provided
+        executor.execute(applicationContext.getBean(InitializeNodesTask.class));
+
         // Reconnect peers on startup
         executor.execute(applicationContext.getBean(LoadPeersTask.class));
 
@@ -481,7 +485,7 @@ public class GethHttpServiceImpl implements GethHttpService {
                 saveProps = true;
             }
 
-            //Set permissioned 
+            //Set permissioned
             if (gethConfig.isPermissionedNode()) {
                 additionalParams.add("--permissioned");
             } else if (StringUtils.isNotBlank(System.getProperty("geth.permissioned"))

--- a/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/service/task/InitializeNodesTask.java
+++ b/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/service/task/InitializeNodesTask.java
@@ -1,0 +1,57 @@
+package com.jpmorgan.cakeshop.service.task;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jpmorgan.cakeshop.dao.NodeInfoDAO;
+import com.jpmorgan.cakeshop.model.NodeInfo;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+@Scope("prototype")
+public class InitializeNodesTask implements Runnable {
+
+    private static final org.slf4j.Logger LOG = org.slf4j.LoggerFactory
+        .getLogger(InitializeNodesTask.class);
+
+    @Value("${cakeshop.initialnodes:}")
+    String initialNodesFile;
+
+    private final NodeInfoDAO nodeInfoDAO;
+
+    private final ObjectMapper jsonMapper;
+
+    @Autowired
+    public InitializeNodesTask(NodeInfoDAO nodeInfoDAO,
+        ObjectMapper jsonMapper) {
+        this.nodeInfoDAO = nodeInfoDAO;
+        this.jsonMapper = jsonMapper;
+    }
+
+    @Override
+    public void run() {
+        if (StringUtils.isEmpty(initialNodesFile)) {
+            return;
+        }
+
+        try {
+            if (nodeInfoDAO.list().isEmpty()) {
+                LOG.info("Loading initial nodes from: {}", initialNodesFile);
+                List<NodeInfo> nodes = jsonMapper
+                    .readValue(new File(initialNodesFile), new TypeReference<List<NodeInfo>>() {
+                    });
+                nodeInfoDAO.save(nodes);
+            }
+        } catch (IOException e) {
+            LOG.error("Could not load initial nodes file", e);
+        }
+
+    }
+
+}

--- a/cakeshop-api/src/main/webapp/.babelrc
+++ b/cakeshop-api/src/main/webapp/.babelrc
@@ -6,6 +6,7 @@
     "plugins": [
         "@babel/plugin-transform-modules-commonjs",
         "babel-plugin-transform-class-properties",
-        "transform-promise-to-bluebird"
+        "transform-promise-to-bluebird",
+        "@babel/plugin-transform-runtime"
     ]
 }

--- a/cakeshop-api/src/main/webapp/js/components/AddNodeDialog.js
+++ b/cakeshop-api/src/main/webapp/js/components/AddNodeDialog.js
@@ -12,15 +12,15 @@ import Button from "@material-ui/core/Button";
 export const AddNodeDialog = ({open, onSubmit, onCancel}) => {
 
     const [name, setName] = useState("");
-    const [geth, setGeth] = useState("http://localhost:22000");
-    const [tessera, setTessera] = useState("http://localhost:9001");
+    const [rpcUrl, setRpcUrl] = useState("http://localhost:22000");
+    const [transactionManagerUrl, setTransactionManagerUrl] = useState("http://localhost:9001");
     return (
         <Dialog open={open} onClose={onCancel}
                 aria-labelledby="form-dialog-title">
             <DialogTitle id="form-dialog-title">Add Node</DialogTitle>
             <form onSubmit={(e) => {
                 e.preventDefault();
-                onSubmit({name, geth, tessera});
+                onSubmit({name, rpcUrl, transactionManagerUrl});
             }}>
                 <DialogContent>
                     <DialogContentText>
@@ -42,9 +42,9 @@ export const AddNodeDialog = ({open, onSubmit, onCancel}) => {
                         id="geth"
                         label="Geth RPC Url"
                         type="url"
-                        value={geth}
+                        value={rpcUrl}
                         fullWidth
-                        onChange={(e) => setGeth(e.target.value)}
+                        onChange={(e) => setRpcUrl(e.target.value)}
                     />
                     <TextField
                         margin="dense"
@@ -53,7 +53,7 @@ export const AddNodeDialog = ({open, onSubmit, onCancel}) => {
                         defaultValue="http://localhost:9001"
                         type="url"
                         fullWidth
-                        onChange={(e) => setTessera(e.target.value)}
+                        onChange={(e) => setTransactionManagerUrl(e.target.value)}
                     />
                 </DialogContent>
                 <DialogActions>

--- a/cakeshop-api/src/main/webapp/js/components/Manage.js
+++ b/cakeshop-api/src/main/webapp/js/components/Manage.js
@@ -1,14 +1,13 @@
-import React, {Component} from 'react';
-import {DragAndDropButton} from "./DragAndDropButton";
-import {AddNodeDialog} from "./AddNodeDialog";
-import {NodeGrid} from "./NodeGrid";
-import ArrowBack from "@material-ui/icons/ArrowBack";
-import AppBar from "@material-ui/core/AppBar";
-import Toolbar from "@material-ui/core/Toolbar";
-import IconButton from "@material-ui/core/IconButton";
-import Typography from "@material-ui/core/Typography";
-import Container from "@material-ui/core/Container";
-import {getNodesFromLocalStorage, saveNodesToLocalStorage} from "./node_utils";
+import React, { Component } from 'react'
+import { DragAndDropButton } from './DragAndDropButton'
+import { AddNodeDialog } from './AddNodeDialog'
+import { NodeGrid } from './NodeGrid'
+import ArrowBack from '@material-ui/icons/ArrowBack'
+import AppBar from '@material-ui/core/AppBar'
+import Toolbar from '@material-ui/core/Toolbar'
+import IconButton from '@material-ui/core/IconButton'
+import Typography from '@material-ui/core/Typography'
+import Container from '@material-ui/core/Container'
 
 export default class Manage extends Component {
     constructor(props) {
@@ -22,7 +21,20 @@ export default class Manage extends Component {
     }
 
     componentDidMount() {
-        this.setState({nodes: getNodesFromLocalStorage()});
+        let _this = this
+
+        fetch(this.getUrl('api/node/nodes'), {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+        })
+        .then((response => {return response.json()}))
+        .then(function (response) {
+            let nodes = response.data.attributes.result
+            console.log('nodes:', nodes)
+            _this.setState({ nodes })
+        })
     }
 
     render() {
@@ -41,7 +53,7 @@ export default class Manage extends Component {
                         </Typography>
                         <DragAndDropButton
                             onClick={this.onAddNodeClick}
-                            onConfigLoaded={this.onConfigLoaded}/>
+                            onConfigLoaded={this.onNodesJsonLoaded}/>
                     </Toolbar>
                 </AppBar>
                 <Container style={{marginTop: 84}}>
@@ -60,11 +72,28 @@ export default class Manage extends Component {
         this.setState({dialogOpen: true})
     };
 
-    onConfigLoaded = (config) => {
-        console.log("Config successfully loaded:", config);
-        if (config.nodes != null && config.nodes.length > 0) {
-            saveNodesToLocalStorage(config.nodes);
-            this.setState({nodes: config.nodes})
+    onNodesJsonLoaded = async (newNodes) => {
+        console.log('Nodes successfully loaded:', newNodes)
+        if (newNodes != null && newNodes.length > 0) {
+            const response = await fetch(this.getUrl('api/node/addAll'), {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(newNodes)
+            })
+            console.log('add response:', response)
+            if (response.status === 201) {
+                console.log('Success:', response.status, response.statusText)
+                this.setState((prevState) => {
+                    return {
+                        ...prevState,
+                        nodes: [...prevState.nodes, ...newNodes]
+                    }
+                })
+            } else {
+                console.log('Error:', response.status, response.statusText)
+            }
         }
     };
 
@@ -72,26 +101,27 @@ export default class Manage extends Component {
         this.setState({dialogOpen: false})
     };
 
-    onSubmit = ({name, geth, tessera}) => {
+    onSubmit = async (newNode) => {
         this.setState({dialogOpen: false});
-        const newNode = {
-            name,
-            geth: {
-                url: geth
+        const response = await fetch(this.getUrl('api/node/add'), {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
             },
-            tessera: {
-                url: tessera
-            }
-        };
-        this.setState((prevState) => {
-            const {nodes} = prevState;
-            let newNodes = [...nodes, newNode];
-            saveNodesToLocalStorage(newNodes);
-            return {
-                ...prevState,
-                nodes: newNodes
-            }
+            body: JSON.stringify(newNode)
         })
+        if (response.status === 201) {
+            this.setState((prevState) => {
+                const { nodes } = prevState
+                let newNodes = [...nodes, newNode]
+                return {
+                    ...prevState,
+                    nodes: newNodes
+                }
+            })
+        } else {
+            console.log('Error:', response.status, response.statusText)
+        }
     };
 
     onView = (node) => {
@@ -101,11 +131,7 @@ export default class Manage extends Component {
             headers: {
                 'Content-Type': 'application/json'
             },
-            body: JSON.stringify(
-                {
-                    url: node.geth.url,
-                    transactionManagerUrl: node.tessera.url
-                })
+            body: JSON.stringify(node)
         }).then(response => {
             if (response.status === 200) {
                 console.log("Success:", response.status, response.statusText);
@@ -125,15 +151,25 @@ export default class Manage extends Component {
         return `${protocol}//${host}/${path}`;
     };
 
-    onDismiss = (nodeToRemove) => {
-        this.setState((prevState) => {
-            const {nodes} = prevState;
-            let newNodes = nodes.filter((node) => node !== nodeToRemove);
-            saveNodesToLocalStorage(newNodes);
-            return {
-                ...prevState,
-                nodes: newNodes
-            }
+    onDismiss = async (nodeToRemove) => {
+        const response = await fetch(this.getUrl('api/node/remove'), {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(nodeToRemove)
         })
+        if (response.status === 204) {
+            this.setState((prevState) => {
+                const { nodes } = prevState
+                let newNodes = nodes.filter((node) => node !== nodeToRemove)
+                return {
+                    ...prevState,
+                    nodes: newNodes
+                }
+            })
+        } else {
+            console.log('Error:', response.status, response.statusText)
+        }
     }
 }

--- a/cakeshop-api/src/main/webapp/js/components/NodeChooser.js
+++ b/cakeshop-api/src/main/webapp/js/components/NodeChooser.js
@@ -1,6 +1,5 @@
 import React, {Component} from "react";
 import Select from "react-select";
-import {getNodesFromLocalStorage} from "./node_utils";
 
 const MANAGE_NODES_OPTION = {label: "Manage Nodes...", value: "manage"};
 
@@ -27,18 +26,17 @@ export default class NodeChooser extends Component {
 
     componentDidMount() {
         const _this = this;
-        Client.get('api/node/currentUrl')
+        Client.get('api/node/nodes')
         .done(function (response) {
             _this.setState((prevState) => {
-                let currentUrl = response.data.attributes.result;
                 let selectedNode = prevState.selectedNode;
-                let nodes = getNodesFromLocalStorage().map((node) => {
+                let nodes = response.data.attributes.result.map((node) => {
                     const option = {
                         label: node.name,
-                        value: node.geth.url
+                        value: node
                     };
 
-                    if (option.value === currentUrl) {
+                    if(node.isSelected) {
                         selectedNode = option;
                     }
 
@@ -60,17 +58,14 @@ export default class NodeChooser extends Component {
             Client.get('api/node/currentUrl')
             .done(function (response) {
                 let currentUrl = response.data.attributes.result;
-                if (currentUrl !== _this.state.selectedNode.value) {
+                if (currentUrl !== _this.state.selectedNode.value.rpcUrl) {
                     console.log("Current url doesn't match dropdown, reloading",
-                        currentUrl, _this.state.selectedNode.value);
+                        currentUrl, _this.state.selectedNode.value.rpcUrl);
                     window.location.reload();
                 }
             })
         })
     }
-
-    getNodeForUrl = (url) => getNodesFromLocalStorage().filter(
-        (node) => node.geth.url === url)[0];
 
     onChange = (option, action, other) => {
         if (option.value === "manage") {
@@ -78,9 +73,8 @@ export default class NodeChooser extends Component {
             return;
         }
 
-        let node = this.getNodeForUrl(option.value);
-        Client.post('api/node/url',
-            {url: node.geth.url, transactionManagerUrl: node.tessera.url})
+        let node = option.value;
+        Client.post('api/node/url', node)
         .done(function (response) {
             console.log("success", response);
             window.location.reload();

--- a/cakeshop-api/src/main/webapp/js/components/NodeGrid.js
+++ b/cakeshop-api/src/main/webapp/js/components/NodeGrid.js
@@ -21,7 +21,7 @@ export const NodeGrid = ({list, onView, onDismiss}) => {
     return <Grid container spacing={2}>
         {list.map(node =>
             <Grid item
-                  key={node.geth.url} zeroMinWidth>
+                  key={node.rpcUrl} zeroMinWidth>
                 <Card className={classes.card}>
                     <CardContent className={classes.cardContent}>
                         <Typography variant="h6" component="h3" gutterBottom>
@@ -29,11 +29,11 @@ export const NodeGrid = ({list, onView, onDismiss}) => {
                         </Typography>
                         <Typography variant="subtitle2" color="textSecondary"
                                     noWrap>
-                            {node.geth.url}
+                            {node.rpcUrl}
                         </Typography>
                         <Typography variant="subtitle2" color="textSecondary"
                                     noWrap>
-                            {node.tessera.url}
+                            {node.transactionManagerUrl}
                         </Typography>
                     </CardContent>
                     <CardActions>

--- a/cakeshop-api/src/main/webapp/js/components/PrivateFor.js
+++ b/cakeshop-api/src/main/webapp/js/components/PrivateFor.js
@@ -1,6 +1,5 @@
 import React, {Component} from "react";
 import Creatable from "react-select/creatable";
-import {getNodesFromLocalStorage} from "./node_utils";
 
 export class PrivateFor extends Component {
 
@@ -24,11 +23,15 @@ export class PrivateFor extends Component {
 
     componentDidMount() {
         const {initialPrivateFor} = this.props;
+        let _this = this;
         Client.post('api/node/tm/peers')
         .then((response) => {
-            const nodes = getNodesFromLocalStorage();
             const parties = response.data.attributes.result.keys;
-            this.setOptionsAndsSelection(parties, nodes, initialPrivateFor);
+            Client.get('api/node/nodes')
+            .done(function (response) {
+                    let nodes = response.data.attributes.result;
+                _this.setOptionsAndsSelection(parties, nodes, initialPrivateFor);
+            })
         })
     }
 
@@ -54,11 +57,11 @@ export class PrivateFor extends Component {
         };
         nodes.forEach((node) => {
             // urls from tessera always have the trailing slash
-            if (!node.tessera.url.endsWith("/")) {
-                node.tessera.url += "/"
+            if (!node.transactionManagerUrl.endsWith("/")) {
+                node.transactionManagerUrl += "/"
             }
 
-            if (node.tessera.url === party.url) {
+            if (node.transactionManagerUrl === party.url) {
                 option.label = `${node.name} (${party.key})`
             }
         });

--- a/cakeshop-api/src/main/webapp/js/components/node_utils.js
+++ b/cakeshop-api/src/main/webapp/js/components/node_utils.js
@@ -1,7 +1,0 @@
-export function getNodesFromLocalStorage() {
-    return JSON.parse(localStorage.getItem("nodes") || "[]");
-}
-
-export function saveNodesToLocalStorage(nodes) {
-    localStorage.setItem("nodes", JSON.stringify(nodes));
-}

--- a/cakeshop-api/src/main/webapp/package.json
+++ b/cakeshop-api/src/main/webapp/package.json
@@ -14,7 +14,7 @@
     "@babel/cli": "^7.5.0",
     "@babel/core": "^7.5.4",
     "@babel/plugin-transform-modules-commonjs": "^7.5.0",
-    "@babel/plugin-transform-runtime": "^7.5.0",
+    "@babel/plugin-transform-runtime": "^7.6.2",
     "@babel/preset-env": "^7.5.4",
     "@babel/preset-react": "^7.0.0",
     "babel-loader": "^8.0.6",


### PR DESCRIPTION
Two goals for this PR:
- Move Nodes from localstorage to the cakeshop db. Updating ui and api accordingly
- Allow an initial list of nodes to be specified in application.properties to prepopulate the DB. For example, we can add cakeshop to 7nodes and have the nodes already configured in the ui the first time the user opens it.
