### PR TITLE
Ui fixes

### DIFF
--- a/cakeshop-api/src/main/webapp/js/components/Manage.js
+++ b/cakeshop-api/src/main/webapp/js/components/Manage.js
@@ -21,6 +21,10 @@ export default class Manage extends Component {
     }
 
     componentDidMount() {
+        this.fetchNodes()
+    }
+
+    fetchNodes () {
         let _this = this
 
         fetch('api/node/nodes', {
@@ -85,12 +89,7 @@ export default class Manage extends Component {
             console.log('add response:', response)
             if (response.status === 201) {
                 console.log('Success:', response.status, response.statusText)
-                this.setState((prevState) => {
-                    return {
-                        ...prevState,
-                        nodes: [...prevState.nodes, ...newNodes]
-                    }
-                })
+                this.fetchNodes()
             } else {
                 console.log('Error:', response.status, response.statusText)
             }
@@ -111,14 +110,7 @@ export default class Manage extends Component {
             body: JSON.stringify(newNode)
         })
         if (response.status === 201) {
-            this.setState((prevState) => {
-                const { nodes } = prevState
-                let newNodes = [...nodes, newNode]
-                return {
-                    ...prevState,
-                    nodes: newNodes
-                }
-            })
+            this.fetchNodes()
         } else {
             console.log('Error:', response.status, response.statusText)
         }

--- a/cakeshop-api/src/main/webapp/js/components/NodeGrid.js
+++ b/cakeshop-api/src/main/webapp/js/components/NodeGrid.js
@@ -21,7 +21,7 @@ export const NodeGrid = ({list, onView, onDismiss}) => {
     return <Grid container spacing={2}>
         {list.map(node =>
             <Grid item
-                  key={node.rpcUrl} zeroMinWidth>
+                  key={node.id} zeroMinWidth>
                 <Card className={classes.card}>
                     <CardContent className={classes.cardContent}>
                         <Typography variant="h6" component="h3" gutterBottom>

--- a/cakeshop-api/src/main/webapp/js/index.js
+++ b/cakeshop-api/src/main/webapp/js/index.js
@@ -68,7 +68,7 @@ window.Tower = {
 			 .addClass('fa-pause tower-txt-danger');
 		}
 
-        utils.prettyUpdate(Tower.status.peerCount, this.getPeerNumberText(status), $('#default-peers'));
+        utils.prettyUpdate(Tower.status.peerCount, utils.getPeerNumberText(status), $('#default-peers'));
 		utils.prettyUpdate(Tower.status.latestBlock, status.latestBlock, $('#default-blocks'));
 		utils.prettyUpdate(Tower.status.pendingTxn, status.pendingTxn, $('#default-txn'));
 
@@ -369,12 +369,6 @@ window.Tower = {
 		return typeof window !== 'undefined' && window !== null ? (_ref = window.console) !== null ? _ref.log(message) : void 0 : void 0;
 	},
 
-    getPeerNumberText: function (status) {
-        const peers = status.peers ? status.peers : []
-        const connected = peers.filter(peer => peer.status === 'running').length
-        const total = peers.length
-        return connected < total ? `${connected}/${total}` : total
-    },
 };
 
 $(function() {

--- a/cakeshop-api/src/main/webapp/js/utils.js
+++ b/cakeshop-api/src/main/webapp/js/utils.js
@@ -1,3 +1,5 @@
+import $ from 'jquery'
+
 export default {
 	load: function(opts) {
 		var config = {
@@ -138,6 +140,13 @@ export default {
         }
         // now that we're in millis, get user friendly time
         return Math.round(timestamp);
+    },
+
+    getPeerNumberText: function (status) {
+        const peers = status.peers ? status.peers : []
+        const connected = peers.filter(peer => peer.status === 'running').length
+        const total = peers.length
+        return connected < total ? `${connected}/${total}` : total
     }
 
 };


### PR DESCRIPTION
Fixes some bugs in the frontend:
- Node entries with the same rpc url were messing up the node grid. Now that each node has a unique id in the db, we can use that for the react list item key.
- New nodes weren't getting the database id back from the create request. Just refetch the list after a successful addition of any nodes.
- There was an error log in the console because of an issue with 'this' being wrong sometimes in the status update method. Moved the getPeerNumberText function to utils since it was a pure function anyway.