### PR TITLE
Updates PrivateFor to use full partyinfo url to be compatible with bo…

### DIFF
--- a/7nodes.json
+++ b/7nodes.json
@@ -2,36 +2,36 @@
   {
     "name": "node1",
     "rpcUrl": "http://localhost:22000",
-    "transactionManagerUrl": "http://localhost:9001"
+    "transactionManagerUrl": "http://localhost:9001/partyinfo"
   },
   {
     "name": "node2",
     "rpcUrl": "http://localhost:22001",
-    "transactionManagerUrl": "http://localhost:9002"
+    "transactionManagerUrl": "http://localhost:9002/partyinfo"
   },
   {
     "name": "node3",
     "rpcUrl": "http://localhost:22002",
-    "transactionManagerUrl": "http://localhost:9003"
+    "transactionManagerUrl": "http://localhost:9003/partyinfo"
   },
   {
     "name": "node4",
     "rpcUrl": "http://localhost:22003",
-    "transactionManagerUrl": "http://localhost:9004"
+    "transactionManagerUrl": "http://localhost:9004/partyinfo"
   },
   {
     "name": "node5",
     "rpcUrl": "http://localhost:22004",
-    "transactionManagerUrl": "http://localhost:9005"
+    "transactionManagerUrl": "http://localhost:9005/partyinfo"
   },
   {
     "name": "node6",
     "rpcUrl": "http://localhost:22005",
-    "transactionManagerUrl": "http://localhost:9006"
+    "transactionManagerUrl": "http://localhost:9006/partyinfo"
   },
   {
     "name": "node7",
     "rpcUrl": "http://localhost:22006",
-    "transactionManagerUrl": "http://localhost:9007"
+    "transactionManagerUrl": "http://localhost:9007/partyinfo"
   }
 ]

--- a/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/controller/NodeController.java
+++ b/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/controller/NodeController.java
@@ -213,7 +213,7 @@ public class NodeController extends BaseController {
         jsonContentHeaders.setContentType(APPLICATION_JSON);
         HttpEntity<String> httpEntity = new HttpEntity<>(jsonContentHeaders);
         ResponseEntity<Map> exchange = restTemplate
-            .exchange(transactionManagerUrl + "/partyinfo", HttpMethod.GET, httpEntity, Map.class);
+            .exchange(transactionManagerUrl, HttpMethod.GET, httpEntity, Map.class);
         return new ResponseEntity<>(APIResponse.newSimpleResponse(exchange.getBody()), HttpStatus.OK);
     }
 

--- a/cakeshop-api/src/main/webapp/js/components/AddNodeDialog.js
+++ b/cakeshop-api/src/main/webapp/js/components/AddNodeDialog.js
@@ -13,7 +13,7 @@ export const AddNodeDialog = ({open, onSubmit, onCancel}) => {
 
     const [name, setName] = useState("");
     const [rpcUrl, setRpcUrl] = useState("http://localhost:22000");
-    const [transactionManagerUrl, setTransactionManagerUrl] = useState("http://localhost:9001");
+    const [transactionManagerUrl, setTransactionManagerUrl] = useState("http://localhost:9001/partyinfo");
     return (
         <Dialog open={open} onClose={onCancel}
                 aria-labelledby="form-dialog-title">
@@ -49,8 +49,8 @@ export const AddNodeDialog = ({open, onSubmit, onCancel}) => {
                     <TextField
                         margin="dense"
                         id="tessera"
-                        label="Tessera P2P Url (optional)"
-                        defaultValue="http://localhost:9001"
+                        label="Tessera Party Keys Url (optional)"
+                        value={transactionManagerUrl}
                         type="url"
                         fullWidth
                         onChange={(e) => setTransactionManagerUrl(e.target.value)}

--- a/cakeshop-api/src/main/webapp/js/components/PrivateFor.js
+++ b/cakeshop-api/src/main/webapp/js/components/PrivateFor.js
@@ -1,5 +1,5 @@
-import React, {Component} from "react";
-import Creatable from "react-select/creatable";
+import React, { Component } from 'react'
+import Creatable from 'react-select/creatable'
 
 export class PrivateFor extends Component {
 
@@ -27,17 +27,13 @@ export class PrivateFor extends Component {
         Client.post('api/node/tm/peers')
         .then((response) => {
             const parties = response.data.attributes.result.keys;
-            Client.get('api/node/nodes')
-            .done(function (response) {
-                    let nodes = response.data.attributes.result;
-                _this.setOptionsAndsSelection(parties, nodes, initialPrivateFor);
-            })
+            _this.setOptionsAndsSelection(parties, initialPrivateFor);
         })
     }
 
-    setOptionsAndsSelection = (parties, nodes, initialPrivateFor) => {
+    setOptionsAndsSelection = (parties, initialPrivateFor) => {
         const options = parties
-            .map(party => this.createOption(party, nodes))
+            .map(party => this.createOption(party))
             .sort((a, b) => a.label.localeCompare(b.label));
 
         const initialSelection = options.filter(
@@ -50,22 +46,11 @@ export class PrivateFor extends Component {
         this.sendOptionsToParent(initialSelection);
     };
 
-    createOption(party, nodes) {
-        let option = {
+    createOption(party) {
+        return {
             value: party.key,
             label: party.key // default to just the key
         };
-        nodes.forEach((node) => {
-            // urls from tessera always have the trailing slash
-            if (!node.transactionManagerUrl.endsWith("/")) {
-                node.transactionManagerUrl += "/"
-            }
-
-            if (node.transactionManagerUrl === party.url) {
-                option.label = `${node.name} (${party.key})`
-            }
-        });
-        return option;
     }
 
     sendOptionsToParent(options) {


### PR DESCRIPTION
…th tessera 0.10.2+ and <0.10.1

Also no longer uses the 'url' value from partyinfo, because 0.10.2+ won't include it

Tessera will be adding a /partyinfo/keys endpoint to the 3rd Party server. It is recommended to use this over the other P2P /partyinfo endpoint. If we require the user to specify the url directly to the partyinfo endpoint, we can support both.

Update the default url once the new version of tessera is out.