### PR TITLE
Fixes bug where config file is copied after initialization

### DIFF
--- a/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/bean/GethRunner.java
+++ b/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/bean/GethRunner.java
@@ -65,7 +65,6 @@ public class GethRunner {
      * Reset back to vendored config file and re-init bean config
      */
     public void initFromVendorConfig() throws IOException {
-//        AppConfig.initVendorConfig(new File(configFile));
         initBean();
     }
 

--- a/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/service/impl/GethHttpServiceImpl.java
+++ b/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/service/impl/GethHttpServiceImpl.java
@@ -456,7 +456,6 @@ public class GethHttpServiceImpl implements GethHttpService {
                 transactionManagerUrl);
             LOG.info("Couldn't find node in db, adding, {}", embeddedNodeInfo.id);
             nodeInfoDao.save(embeddedNodeInfo);
-            LOG.info("does it have an id now? {}", embeddedNodeInfo.id);
         }
         connectToNode(embeddedNodeInfo.id);
     }

--- a/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/util/FileUtils.java
+++ b/cakeshop-api/src/main/java/com/jpmorgan/cakeshop/util/FileUtils.java
@@ -11,7 +11,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.SystemUtils;
 
 public class FileUtils extends org.apache.commons.io.FileUtils {
-    
+
 
     /**
      * Join the given paths and expand any relative locations (. or ..) to their full canonical form
@@ -143,7 +143,7 @@ public class FileUtils extends org.apache.commons.io.FileUtils {
      */
     public static String getTempPath(String prefix) {
         try {
-            File temp = File.createTempFile("ee-", "");
+            File temp = File.createTempFile(prefix, "");
             temp.delete();
             return temp.getPath();
         } catch (IOException e) {

--- a/cakeshop-api/src/test/java/com/jpmorgan/cakeshop/test/config/TestAppConfig.java
+++ b/cakeshop-api/src/test/java/com/jpmorgan/cakeshop/test/config/TestAppConfig.java
@@ -56,7 +56,9 @@ public class TestAppConfig implements EnvironmentAware {
     @Profile("test")
     public PropertySourcesPlaceholderConfigurer propertySourcesPlaceholderConfigurer() throws IOException {
         AppConfig appConfig = new AppConfig();
-        return appConfig.createPropConfigurer(TempFileManager.getTempPath());
+        String tempPath = TempFileManager.getTempPath();
+        AppConfig.createConfigIfNecessary(tempPath);
+        return appConfig.createPropConfigurer(tempPath);
     }
 
     @Bean(name = "asyncExecutor")


### PR DESCRIPTION
We were copying application.properties to the data folder after spring
had started. So some beans weren't getting the correct values on first
run (hibernate Conditional beans). Instead we copy, if necessary, in the
main method.

Configuration is still complicated and needs to be reworked.