### PR TITLE
Enhancement debian package manager tweaks

### DIFF
--- a/docker/cakeshop/Dockerfile
+++ b/docker/cakeshop/Dockerfile
@@ -20,12 +20,11 @@ RUN set -x \
     && addgroup --gid ${gid} --system ${group} \
     && adduser --system --home "$CAKESHOP_HOME" --shell /sbin/nologin --ingroup ${group} ${user} \
     && apt-get update \
-    && apt-get -y install curl \
+    && apt-get --no-install-recommends -y install apt-utils ca-certificates curl wget \
     && curl -sL https://deb.nodesource.com/setup_12.x | bash - \
-    && apt-get install -y nodejs \
+    && apt-get --no-install-recommends install -y nodejs \
     && curl -fsSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-static -o /bin/tini && chmod +x /bin/tini \
     && echo "$TINI_SHA  /bin/tini" | sha256sum -c - \
-    && apt-get install -y --no-install-recommends ca-certificates wget && rm -rf /var/lib/apt/lists/* \
     && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
     && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" \
     && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \


### PR DESCRIPTION
Major Changes No 1 : debian package manager tweaks

By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Major Changes No 2 : added packages apt-utils ca-certificates

Because build is

1.  Slow because "apt-utils" not installed

2. to avoid build to exits with error without having certificate

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>